### PR TITLE
chore: CATALOG-11541 Use catalog changes in fork repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "php-amqplib/php-amqplib": "^v3.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^11.0",
         "mockery/mockery": "^1.0",
         "laravel/horizon": "^5.0",
         "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "laravel/pint": "^1.2",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0"
+        "laravel/framework": "^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -33,9 +33,6 @@
         }
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "13.0-dev"
-        },
         "laravel": {
             "providers": [
                 "VladimirYuldashev\\LaravelQueueRabbitMQ\\LaravelQueueRabbitMQServiceProvider"

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -38,6 +38,7 @@ class ConfigFactory
             self::getHostFromConfig($connectionConfig, $config);
             self::getHeartbeatFromConfig($connectionConfig, $config);
             self::getNetworkProtocolFromConfig($connectionConfig, $config);
+            self::getReadWriteTimeoutFromConfig($connectionConfig, $config);
         });
     }
 
@@ -97,6 +98,20 @@ class ConfigFactory
     {
         if ($networkProtocol = Arr::get($config, 'network_protocol')) {
             $connectionConfig->setNetworkProtocol($networkProtocol);
+        }
+    }
+
+    protected static function getReadWriteTimeoutFromConfig(AMQPConnectionConfig $connectionConfig, array $config): void
+    {
+        $readTimeout = Arr::get($config, self::CONFIG_OPTIONS.'.read_timeout');
+        $writeTimeout = Arr::get($config, self::CONFIG_OPTIONS.'.write_timeout');
+
+        if (is_numeric($readTimeout) && intval($readTimeout) > 0) {
+            $connectionConfig->setReadTimeout((int) $readTimeout);
+        }
+
+        if (is_numeric($writeTimeout) && intval($writeTimeout) > 0) {
+            $connectionConfig->setWriteTimeout((int) $readTimeout);
         }
     }
 }

--- a/src/Queue/Connection/ConfigFactory.php
+++ b/src/Queue/Connection/ConfigFactory.php
@@ -18,17 +18,21 @@ class ConfigFactory
     {
         return tap(new AMQPConnectionConfig, function (AMQPConnectionConfig $connectionConfig) use ($config) {
             // Set the connection to a Lazy by default
-            $connectionConfig->setIsLazy(! in_array(
-                Arr::get($config, 'lazy') ?? true,
-                [false, 0, '0', 'false', 'no'],
-                true)
+            $connectionConfig->setIsLazy(
+                ! in_array(
+                    Arr::get($config, 'lazy') ?? true,
+                    [false, 0, '0', 'false', 'no'],
+                    true
+                )
             );
 
             // Set the connection to unsecure by default
-            $connectionConfig->setIsSecure(in_array(
-                Arr::get($config, 'secure'),
-                [true, 1, '1', 'true', 'yes'],
-                true)
+            $connectionConfig->setIsSecure(
+                in_array(
+                    Arr::get($config, 'secure'),
+                    [true, 1, '1', 'true', 'yes'],
+                    true
+                )
             );
 
             if ($connectionConfig->isSecure()) {
@@ -106,12 +110,18 @@ class ConfigFactory
         $readTimeout = Arr::get($config, self::CONFIG_OPTIONS.'.read_timeout');
         $writeTimeout = Arr::get($config, self::CONFIG_OPTIONS.'.write_timeout');
 
-        if (is_numeric($readTimeout) && intval($readTimeout) > 0) {
-            $connectionConfig->setReadTimeout((int) $readTimeout);
+        if (is_numeric($readTimeout)) {
+            $timeoutValue = (int) $readTimeout;
+            if ($timeoutValue > 0) {
+                $connectionConfig->setReadTimeout($timeoutValue);
+            }
         }
 
-        if (is_numeric($writeTimeout) && intval($writeTimeout) > 0) {
-            $connectionConfig->setWriteTimeout((int) $readTimeout);
+        if (is_numeric($writeTimeout)) {
+            $timeoutValue = (int) $writeTimeout;
+            if ($timeoutValue > 0) {
+                $connectionConfig->setWriteTimeout($timeoutValue);
+            }
         }
     }
 }

--- a/tests/Feature/ConnectorTest.php
+++ b/tests/Feature/ConnectorTest.php
@@ -168,6 +168,8 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
                     'verify_peer' => false,
                     'passphrase' => null,
                 ],
+                'read_timeout' => 10,
+                'write_timeout' => 15,
             ],
 
             'worker' => env('RABBITMQ_WORKER', 'default'),
@@ -180,8 +182,10 @@ class ConnectorTest extends \VladimirYuldashev\LaravelQueueRabbitMQ\Tests\TestCa
         $connection = $queue->connection('rabbitmq');
         $this->assertInstanceOf(RabbitMQQueue::class, $connection);
         $this->assertInstanceOf(AMQPSSLConnection::class, $connection->getConnection());
-        /** @var AMQPConnectionConfig */
+        /** @var AMQPConnectionConfig $config */
         $config = $connection->getConnection()->getConfig();
         $this->assertFalse($config->getSslVerify());
+        $this->assertEquals(10, $config->getReadTimeout());
+        $this->assertEquals(15, $config->getWriteTimeout());
     }
 }


### PR DESCRIPTION
Jira: [CATALOG-11541](https://bigcommercecloud.atlassian.net/browse/CATALOG-11541)

## What/Why?
Use catalog changes in fork repo.
Cherry-picked all commits from previous repo: https://github.com/bc-ochkovskyi/laravel-queue-rabbitmq

## Rollout/Rollback
Revert PR.

## Testing
By unit tests:
<img width="643" alt="Screenshot 2025-05-29 at 13 19 51" src="https://github.com/user-attachments/assets/8cc9aac1-d48f-4d93-9856-96ca9711c889" />

In cat-imex service: https://github.com/bigcommerce/catalog-import-export/pull/568
In orchestrator-imex service: https://github.com/bigcommerce/import-export-service/pull/173

[CATALOG-11541]: https://bigcommercecloud.atlassian.net/browse/CATALOG-11541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ