### PR TITLE
CATALOG-12705: Fix Laravel 12 config property conflict

### DIFF
--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -62,14 +62,14 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
     /**
      * Holds the Configuration
      */
-    protected QueueConfig $config;
+    protected QueueConfig $rabbitMQConfig;
 
     /**
      * RabbitMQQueue constructor.
      */
     public function __construct(QueueConfig $config)
     {
-        $this->config = $config;
+        $this->rabbitMQConfig = $config;
         $this->dispatchAfterCommit = $config->isDispatchAfterCommit();
     }
 
@@ -737,7 +737,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
 
     protected function getConfig(): QueueConfig
     {
-        return $this->config;
+        return $this->rabbitMQConfig;
     }
 
     /**

--- a/src/Queue/RabbitMQQueue.php
+++ b/src/Queue/RabbitMQQueue.php
@@ -293,7 +293,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     public function getJobClass(): string
     {
-        $job = $this->getConfig()->getAbstractJob();
+        $job = $this->getRabbitMQConfig()->getAbstractJob();
 
         throw_if(
             ! is_a($job, RabbitMQJob::class, true),
@@ -309,7 +309,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     public function getQueue($queue = null): string
     {
-        return $queue ?: $this->getConfig()->getQueue();
+        return $queue ?: $this->getRabbitMQConfig()->getQueue();
     }
 
     /**
@@ -523,7 +523,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
             $properties['correlation_id'] = $correlationId;
         }
 
-        if ($this->getConfig()->isPrioritizeDelayed()) {
+        if ($this->getRabbitMQConfig()->isPrioritizeDelayed()) {
             $properties['priority'] = $attempts;
         }
 
@@ -605,16 +605,16 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         // Messages with a priority which is higher than the queue's maximum, are treated as if they were
         // published with the maximum priority.
         // Quorum queues does not support priority.
-        if ($this->getConfig()->isPrioritizeDelayed() && ! $this->getConfig()->isQuorum()) {
-            $arguments['x-max-priority'] = $this->getConfig()->getQueueMaxPriority();
+        if ($this->getRabbitMQConfig()->isPrioritizeDelayed() && ! $this->getRabbitMQConfig()->isQuorum()) {
+            $arguments['x-max-priority'] = $this->getRabbitMQConfig()->getQueueMaxPriority();
         }
 
-        if ($this->getConfig()->isRerouteFailed()) {
+        if ($this->getRabbitMQConfig()->isRerouteFailed()) {
             $arguments['x-dead-letter-exchange'] = $this->getFailedExchange();
             $arguments['x-dead-letter-routing-key'] = $this->getFailedRoutingKey($destination);
         }
 
-        if ($this->getConfig()->isQuorum()) {
+        if ($this->getRabbitMQConfig()->isQuorum()) {
             $arguments['x-queue-type'] = 'quorum';
         }
 
@@ -639,7 +639,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getExchange(?string $exchange = null): string
     {
-        return $exchange ?? $this->getConfig()->getExchange();
+        return $exchange ?? $this->getRabbitMQConfig()->getExchange();
     }
 
     /**
@@ -648,7 +648,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getRoutingKey(string $destination): string
     {
-        return ltrim(sprintf($this->getConfig()->getExchangeRoutingKey(), $destination), '.');
+        return ltrim(sprintf($this->getRabbitMQConfig()->getExchangeRoutingKey(), $destination), '.');
     }
 
     /**
@@ -656,7 +656,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getExchangeType(?string $type = null): string
     {
-        $constant = AMQPExchangeType::class.'::'.Str::upper($type ?: $this->getConfig()->getExchangeType());
+        $constant = AMQPExchangeType::class.'::'.Str::upper($type ?: $this->getRabbitMQConfig()->getExchangeType());
 
         return defined($constant) ? constant($constant) : AMQPExchangeType::DIRECT;
     }
@@ -666,7 +666,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getFailedExchange(?string $exchange = null): string
     {
-        return $exchange ?? $this->getConfig()->getFailedExchange();
+        return $exchange ?? $this->getRabbitMQConfig()->getFailedExchange();
     }
 
     /**
@@ -675,7 +675,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
      */
     protected function getFailedRoutingKey(string $destination): string
     {
-        return ltrim(sprintf($this->getConfig()->getFailedRoutingKey(), $destination), '.');
+        return ltrim(sprintf($this->getRabbitMQConfig()->getFailedRoutingKey(), $destination), '.');
     }
 
     /**
@@ -735,7 +735,7 @@ class RabbitMQQueue extends Queue implements QueueContract, RabbitMQQueueContrac
         return [$destination, $exchange, $exchangeType, $attempts];
     }
 
-    protected function getConfig(): QueueConfig
+    protected function getRabbitMQConfig(): QueueConfig
     {
         return $this->rabbitMQConfig;
     }


### PR DESCRIPTION
Jira: [CATALOG-12705](https://bigcommercecloud.atlassian.net/browse/CATALOG-12705)

## What/Why?

Laravel 12 added an untyped `protected $config` to `Illuminate\Queue\Queue`. This fork's `RabbitMQQueue` declares `protected QueueConfig $config`, which is now a fatal error at class load: `Type of RabbitMQQueue::$config must not be defined (as in class Illuminate\Queue\Queue)`. Any Laravel 12 consumer touching the queue path crashes (found via new QueueWorker unit tests in catalog-common-php; the composer constraint already allowed `^12.0`).

Rename the property to `$rabbitMQConfig`, the same fix upstream shipped in v15 (vladimir-yuldashev/laravel-queue-rabbitmq). 5 lines, one file, no behavior change.

## Rollout/Rollback

Consumed as `dev-master` by catalog-common-php. Takes effect on merge for fresh installs; existing lockfiles pin the old commit until updated. Rollback: revert.

## Testing

`php -l` clean; catalog-common-php unit suite (incl. new QueueWorker tests instantiating RabbitMQQueue doubles) passes against this branch on Laravel 12.64 - verification in bigcommerce/catalog-common-php#193.

[CATALOG-12705]: https://bigcommercecloud.atlassian.net/browse/CATALOG-12705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ